### PR TITLE
fix encoding for ruby 1.9

### DIFF
--- a/lib/imdb/string_extensions.rb
+++ b/lib/imdb/string_extensions.rb
@@ -1,12 +1,16 @@
 require 'cgi'
-require 'iconv'
  
 module Imdb #:nordoc:
   module StringExtensions
   
     # Unescape HTML
     def imdb_unescape_html
-      Iconv.conv("UTF-8", 'ISO-8859-1', CGI::unescapeHTML(self))
+      if String.method_defined?(:encode)
+        CGI::unescapeHTML(self.encode("UTF-8", 'ISO-8859-1'))
+      else
+        require 'iconv'
+        Iconv.conv("UTF-8", 'ISO-8859-1', CGI::unescapeHTML(self)) 
+      end
     end
   
     # Strip tags


### PR DESCRIPTION
use String.encode instead of Iconv.conv
