### PR TITLE
upgraded nokogiri to 1.6 & replaced lambda with new expect syntax

### DIFF
--- a/imdb.gemspec
+++ b/imdb.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
 
-  s.add_dependency 'nokogiri', '~> 1.5.6'
+  s.add_dependency 'nokogiri', '>= 1.6.0'
 
   s.add_development_dependency 'rake', '~> 10.0.3'
   s.add_development_dependency 'rspec', '~> 2.13.0'

--- a/spec/imdb/movie_spec.rb
+++ b/spec/imdb/movie_spec.rb
@@ -51,11 +51,11 @@ describe "Imdb::Movie" do
 
     describe 'fetching a list of imdb actor ids for the cast members' do
       it 'should not require arguments' do
-        lambda { @movie.cast_member_ids }.should_not raise_error(ArgumentError)
+        expect { @movie.cast_member_ids }.not_to raise_error
       end
 
       it 'should not allow arguments' do
-        lambda { @movie.cast_member_ids(:foo) }.should raise_error(ArgumentError)
+        expect { @movie.cast_member_ids(:foo) }.to raise_error(ArgumentError)
       end
 
       it 'should return the imdb actor number for each cast member' do

--- a/spec/imdb/search_spec.rb
+++ b/spec/imdb/search_spec.rb
@@ -30,9 +30,9 @@ end
 describe "Imdb::Search with an exact match and no poster" do
 
   it "should not raise an exception" do
-    lambda {
+    expect {
       @search = Imdb::Search.new("Kannethirey Thondrinal").movies
-    }.should_not raise_error
+    }.not_to raise_error
   end
 
   it "should return the movie id correctly" do


### PR DESCRIPTION
Hey,friend
we should use 1.6 version of nokigiri ,because it's better and is also the dependency of many other gems for now... :)
And, I noticed the deprecated warning , so I replaced lambda with expect syntax in our test specs.

BTW, we do need one release ,because the official 0.7.0 is still using the old and buggy haricot which caused some problems here.

Thanks!
