### PR TITLE
Update base.rb to return multiple directors

### DIFF
--- a/lib/imdb/base.rb
+++ b/lib/imdb/base.rb
@@ -40,9 +40,15 @@ module Imdb
       memb_char
     end
 
-    # Returns the name of the director
-    def director
-      document.search("h5[text()^='Director'] ~ div a").map { |link| link.content.strip } rescue []
+    # Returns the name of the directors
+    def directors
+    	directors_list = []
+    	
+    	fullcredits_document.search("h4[text()^='Directed by'] + table tbody tr td[class='name'] a").each_with_index do |name, i|
+    		directors_list[i] = name.content.strip unless directors_list.include? name.content.strip
+    	end rescue []
+    
+    	directors_list
     end
 
     # Returns the names of Writers

--- a/lib/imdb/base.rb
+++ b/lib/imdb/base.rb
@@ -40,11 +40,11 @@ module Imdb
       memb_char
     end
 
-    # Returns the name of the directors
-    def directors
+    # Returns the name of the director(s)
+    def director
     	directors_list = []
     	
-    	fullcredits_document.search("h4[text()^='Directed by'] + table tbody tr td[class='name'] a").each_with_index do |name, i|
+    	fullcredits_document.search("h4[text()^='Directed by'] + table tbody tr td[class='name']").each_with_index do |name, i|
     		directors_list[i] = name.content.strip unless directors_list.include? name.content.strip
     	end rescue []
     

--- a/spec/imdb/movie_spec.rb
+++ b/spec/imdb/movie_spec.rb
@@ -160,6 +160,16 @@ describe 'Imdb::Movie' do
         movie.director.should include('Lana Wachowski')
         movie.director.should include('Andy Wachowski')
       end
+      
+      it 'should find multiple directors when other directors would be displayed as (more) in combined view' do
+        # The Big Lebowski (1998)
+        movie = Imdb::Movie.new('0118715')
+
+        movie.director.should be_an(Array)
+        movie.director.size.should eql(2)
+        movie.director.should include('Joel Coen')
+        movie.director.should include('Ethan Coen')
+      end
 
       it 'should find writers' do
         # Waar (2013)


### PR DESCRIPTION
The director method already returns an array, but if a movie (such as "The Big Lebowski" or "The Matrix") has more than one director, the second element in the returned array is "(more)". To fix this, I simply searched for directors in the fullcredits_document using the same format as the writers method.
