### PR TITLE
Update to RSpec 3 conventions and syntax

### DIFF
--- a/imdb.gemspec
+++ b/imdb.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'nokogiri', '= 1.6.5'
 
   s.add_development_dependency 'rake', '~> 10.0.3'
-  s.add_development_dependency 'rspec', '~> 2.13.0'
+  s.add_development_dependency 'rspec', '~> 3.0.0'
   s.add_development_dependency 'gokdok'
   s.add_development_dependency 'rdoc', '~> 4.0'
   s.add_development_dependency 'fakeweb'

--- a/spec/imdb/box_office_spec.rb
+++ b/spec/imdb/box_office_spec.rb
@@ -1,21 +1,20 @@
 require 'spec_helper'
 
 describe Imdb::BoxOffice do
-  before(:each) do
-    @movies = Imdb::BoxOffice.new.movies
+  subject { Imdb::BoxOffice.new.movies }
+
+  it 'is list of movies' do
+    subject.each do |movie|
+      expect(movie).to be_a(Imdb::Movie)
+    end
   end
 
-  it 'should be a list of movies' do
-    @movies.each { |movie| movie.should be_an_instance_of(Imdb::Movie) }
+  it 'returns the box office movies from IMDB.com' do
+    expect(subject.length).to eq(10)
   end
 
-  it 'should return the box office movies from IMDB.com' do
-    @movies.size.should eq(10)
-  end
-
-  it 'should provide array like access to the movies' do
-    @movies[0].title.should eq('Big Hero 6')
-    @movies[1].title.should eq('Interstellar')
-    @movies[2].title.should eq('Gone Girl')
+  it 'is an array like access to the movies' do
+    expected_movies = ['Big Hero 6', 'Interstellar', 'Gone Girl']
+    expect(subject.map(&:title)).to include(*expected_movies)
   end
 end

--- a/spec/imdb/episode_spec.rb
+++ b/spec/imdb/episode_spec.rb
@@ -1,37 +1,35 @@
 require 'spec_helper'
 
 describe 'Imdb::Episode' do
-  before(:each) do
-    @serie = Imdb::Serie.new('1520211')
-    @season = @serie.seasons.first
-    @episode = @season.episode(2)
-  end
+  let(:serie)   { Imdb::Serie.new('1520211') }
+  let(:season)  { serie.seasons.first }
+  let(:episode) { season.episode(2) }
 
   it 'has a imdb_id' do
-    @episode.id.should == '1628064'
+    expect(episode.id).to eq('1628064')
   end
 
   it 'has a url' do
-    @episode.url.should == 'http://akas.imdb.com/title/tt1628064/combined'
+    expect(episode.url).to eq('http://akas.imdb.com/title/tt1628064/combined')
   end
 
   it 'has an episode title' do
-    @episode.title.should =~ /Guts/i
+    expect(episode.title).to match(/Guts/i)
   end
 
   it 'has the season number' do
-    @episode.season.should == 1
+    expect(episode.season).to eq(1)
   end
 
   it 'has the episode number' do
-    @episode.episode.should == 2
+    expect(episode.episode).to eq(2)
   end
 
   it 'has a plot' do
-    @episode.plot.should =~ /Rick finds himself trapped with other survivors inside a department store, surrounded by walkers/
+    expect(episode.plot).to match(/Rick finds himself trapped with other survivors inside a department store, surrounded by walkers/)
   end
 
   it 'has a original air data' do
-    @episode.air_date.should eql('7 November 2010')
+    expect(episode.air_date).to eq('7 November 2010')
   end
 end

--- a/spec/imdb/movie_spec.rb
+++ b/spec/imdb/movie_spec.rb
@@ -8,268 +8,264 @@ require 'spec_helper'
 #
 
 describe 'Imdb::Movie' do
-
   describe 'valid movie' do
+    # Get Die Hard (1988)
+    subject { Imdb::Movie.new('0095016') }
 
-    before(:each) do
-      # Get Die Hard (1988)
-      @movie = Imdb::Movie.new('0095016')
+    it 'finds the cast members' do
+      cast = subject.cast_members
+      expected_cast = [
+        'Bruce Willis',
+        'Bonnie Bedelia',
+        'Alan Rickman',
+      ]
+
+      expect(cast).to be_an(Array)
+      expect(cast).to include(*expected_cast)
     end
 
-    it 'should find the cast members' do
-      cast = @movie.cast_members
+    it 'finds the cast characters' do
+      char = subject.cast_characters
+      expected_cast_characters = [
+        'Karl',
+        'Officer John McClane',
+        'Police Detective (uncredited)',
+        'Hostage',
+      ]
 
-      cast.should be_an(Array)
-      cast.should include('Bruce Willis')
-      cast.should include('Bonnie Bedelia')
-      cast.should include('Alan Rickman')
+      expect(char).to be_an(Array)
+      expect(char).to include(*expected_cast_characters)
     end
 
-    it 'should find the cast characters' do
-      char = @movie.cast_characters
+    it 'associates the cast members to the characters' do
+      cast = subject.cast_members
+      char = subject.cast_characters
+      cast_char = subject.cast_members_characters
 
-      char.should be_an(Array)
-      char.should include('Karl')
-      char.should include('Officer John McClane')
-      char.should include('Police Detective (uncredited)')
-      char.should include('Hostage')
-    end
+      expect(cast_char[0]).to eq("#{cast[0]} => #{char[0]}")
+      expect(cast_char[10]).to eq("#{cast[10]} => #{char[10]}")
+      expect(cast_char[-1]).to eq("#{cast[-1]} => #{char[-1]}")
 
-    it 'should associates the cast members to the characters' do
-      cast = @movie.cast_members
-      char = @movie.cast_characters
-      cast_char = @movie.cast_members_characters
+      cast_char = subject.cast_members_characters('as')
 
-      cast_char[0].should eql("#{cast[0]} => #{char[0]}")
-      cast_char[10].should eql("#{cast[10]} => #{char[10]}")
-      cast_char[-1].should eql("#{cast[-1]} => #{char[-1]}")
-
-      cast_char = @movie.cast_members_characters('as')
-
-      cast_char[1].should eql("#{cast[1]} as #{char[1]}")
-      cast_char[11].should eql("#{cast[11]} as #{char[11]}")
-      cast_char[-2].should eql("#{cast[-2]} as #{char[-2]}")
+      expect(cast_char[1]).to eq("#{cast[1]} as #{char[1]}")
+      expect(cast_char[11]).to eq("#{cast[11]} as #{char[11]}")
+      expect(cast_char[-2]).to eq("#{cast[-2]} as #{char[-2]}")
     end
 
     describe 'fetching a list of imdb actor ids for the cast members' do
-      it 'should not require arguments' do
-        expect { @movie.cast_member_ids }.not_to raise_error
+      it 'does not require arguments' do
+        expect { subject.cast_member_ids }.not_to raise_error
       end
 
-      it 'should not allow arguments' do
-        expect { @movie.cast_member_ids(:foo) }.to raise_error(ArgumentError)
+      it 'does not allow arguments' do
+        expect { subject.cast_member_ids(:foo) }.to raise_error(ArgumentError)
       end
 
-      it 'should return the imdb actor number for each cast member' do
-        @movie.cast_member_ids.sort.should == %w(nm0000246 nm0000614 nm0000889 nm0000952 nm0001108 nm0001817 nm0005598 nm0033749 nm0040472 nm0048326 nm0072054 nm0094770 nm0101088 nm0112505 nm0112779 nm0119594 nm0127960 nm0142420 nm0160690 nm0162041 nm0234426 nm0236525 nm0239958 nm0278010 nm0296791 nm0319739 nm0322339 nm0324231 nm0326276 nm0338808 nm0356114 nm0370729 nm0383487 nm0416429 nm0421114 nm0441665 nm0484360 nm0484650 nm0493493 nm0502959 nm0503610 nm0504342 nm0539639 nm0546076 nm0546747 nm0662568 nm0669625 nm0681604 nm0687270 nm0688235 nm0718021 nm0731114 nm0776208 nm0793363 nm0852311 nm0870729 nm0882139 nm0902455 nm0907234 nm0924636 nm0936591 nm0958105 nm2143912 nm2476262 nm2565888).sort
+      it 'returns the imdb actor number for each cast member' do
+        expect(subject.cast_member_ids).to match_array(%w(nm0000246 nm0000614 nm0000889 nm0000952 nm0001108 nm0001817 nm0005598 nm0033749 nm0040472 nm0048326 nm0072054 nm0094770 nm0101088 nm0112505 nm0112779 nm0119594 nm0127960 nm0142420 nm0160690 nm0162041 nm0234426 nm0236525 nm0239958 nm0278010 nm0296791 nm0319739 nm0322339 nm0324231 nm0326276 nm0338808 nm0356114 nm0370729 nm0383487 nm0416429 nm0421114 nm0441665 nm0484360 nm0484650 nm0493493 nm0502959 nm0503610 nm0504342 nm0539639 nm0546076 nm0546747 nm0662568 nm0669625 nm0681604 nm0687270 nm0688235 nm0718021 nm0731114 nm0776208 nm0793363 nm0852311 nm0870729 nm0882139 nm0902455 nm0907234 nm0924636 nm0936591 nm0958105 nm2143912 nm2476262 nm2565888))
       end
     end
 
     it 'returns the url to the movie trailer' do
-      @movie.trailer_url.should be_an(String)
-      @movie.trailer_url.should == 'http://imdb.com/video/screenplay/vi581042457/'
+      expect(subject.trailer_url).to be_a(String)
+      expect(subject.trailer_url).to eq('http://imdb.com/video/screenplay/vi581042457/')
     end
 
-    it 'should find the director' do
-      @movie.director.should be_an(Array)
-      @movie.director.size.should eql(1)
-      @movie.director.first.should =~ /John McTiernan/
+    it 'finds the director' do
+      expect(subject.director).to eq(['John McTiernan'])
     end
 
-    it 'should find the company info' do
-      @movie.company.should eql('Twentieth Century Fox Film Corporation')
+    it 'finds the company info' do
+      expect(subject.company).to eq('Twentieth Century Fox Film Corporation')
     end
 
-    it 'should find the genres' do
-      genres = @movie.genres
-
-      genres.should be_an(Array)
-      genres.should include('Action')
-      genres.should include('Thriller')
+    it 'finds the genres' do
+      expect(subject.genres).to match_array(%w(Action Thriller))
     end
 
-    it 'should find the languages' do
-      languages = @movie.languages
-
-      languages.should be_an(Array)
-      languages.size.should eql(3)
-      languages.should include('English')
-      languages.should include('German')
-      languages.should include('Italian')
+    it 'finds the languages' do
+      expect(subject.languages).to match_array(%w(English German Italian))
     end
 
-    it 'should find the countries' do
+    context 'the Dark Knight' do
       # The Dark Knight (2008)
-      @movie = Imdb::Movie.new('0468569')
-      countries = @movie.countries
+      subject { Imdb::Movie.new('0468569') }
 
-      countries.should be_an(Array)
-      countries.size.should eql(2)
-      countries.should include('USA')
-      countries.should include('UK')
+      it 'finds the countries' do
+        expect(subject.countries).to match_array(%w(USA UK))
+      end
     end
 
-    it 'should find the length (in minutes)' do
-      @movie.length.should eql(131)
+    it 'finds the length (in minutes)' do
+      expect(subject.length).to eq(131)
     end
 
-    it 'should find the plot' do
-      @movie.plot.should eql('John McClane, officer of the NYPD, tries to save wife Holly Gennaro and several others, taken hostage by German terrorist Hans Gruber during a Christmas party at the Nakatomi Plaza in Los Angeles.')
+    it 'finds the plot' do
+      expect(subject.plot).to eq('John McClane, officer of the NYPD, tries to save wife Holly Gennaro and several others, taken hostage by German terrorist Hans Gruber during a Christmas party at the Nakatomi Plaza in Los Angeles.')
     end
 
-    it 'should find plot synopsis' do
-      @movie.plot_synopsis.should =~ /John McClane, a detective with the New York City Police Department, arrives in Los Angeles to attempt a Christmas reunion and reconciliation with his estranged wife Holly, who is attending a party thrown by her employer, the Nakatomi Corporation at its still-unfinished American branch office headquarters, the high-rise Nakatomi Plaza. When McClane refreshes himself from the flight in Holly's corporate room, they have an argument over the use of her maiden name, Gennero, but Holly is called away/
+    it 'finds plot synopsis' do
+      expect(subject.plot_synopsis).to match(/John McClane, a detective with the New York City Police Department, arrives in Los Angeles to attempt a Christmas reunion and reconciliation with his estranged wife Holly, who is attending a party thrown by her employer, the Nakatomi Corporation at its still-unfinished American branch office headquarters, the high-rise Nakatomi Plaza. When McClane refreshes himself from the flight in Holly's corporate room, they have an argument over the use of her maiden name, Gennero, but Holly is called away/)
     end
 
-    it 'should find plot summary' do
-      @movie.plot_summary.should eql("New York City Detective John McClane has just arrived in Los Angeles to spend Christmas with his wife. Unfortunatly, it is not going to be a Merry Christmas for everyone. A group of terrorists, led by Hans Gruber is holding everyone in the Nakatomi Plaza building hostage. With no way of anyone getting in or out, it's up to McClane to stop them all. All 12!")
+    it 'finds plot summary' do
+      expect(subject.plot_summary).to eq("New York City Detective John McClane has just arrived in Los Angeles to spend Christmas with his wife. Unfortunatly, it is not going to be a Merry Christmas for everyone. A group of terrorists, led by Hans Gruber is holding everyone in the Nakatomi Plaza building hostage. With no way of anyone getting in or out, it's up to McClane to stop them all. All 12!")
     end
 
-    it 'should find the poster' do
-      @movie.poster.should eql('http://ia.media-imdb.com/images/M/MV5BMTY4ODM0OTc2M15BMl5BanBnXkFtZTcwNzE0MTk3OA@@.jpg')
+    it 'finds the poster' do
+      expect(subject.poster).to eq('http://ia.media-imdb.com/images/M/MV5BMTY4ODM0OTc2M15BMl5BanBnXkFtZTcwNzE0MTk3OA@@.jpg')
     end
 
-    it 'should find the rating' do
-      @movie.rating.should eql(8.3)
+    it 'finds the rating' do
+      expect(subject.rating).to eq(8.3)
     end
 
-    it 'should find number of votes' do
-      @movie.votes.should be_within(10_000).of(420_900)
+    it 'finds number of votes' do
+      expect(subject.votes).to be_within(10_000).of(420_900)
     end
 
-    it 'should find the title' do
-      @movie.title.should =~ /Die Hard/
+    it 'finds the title' do
+      expect(subject.title).to match(/Die Hard/)
     end
 
-    it 'should find the tagline' do
-      @movie.tagline.should =~ /It will blow you through the back wall of the theater/
+    it 'finds the tagline' do
+      expect(subject.tagline).to match(/It will blow you through the back wall of the theater/)
     end
 
-    it 'should find the year' do
-      @movie.year.should eql(1988)
+    it 'finds the year' do
+      expect(subject.year).to eq(1988)
     end
 
     describe 'special scenarios' do
 
-      it 'should find multiple directors' do
+      context 'The Matrix Revolutions' do
         # The Matrix Revolutions (2003)
-        movie = Imdb::Movie.new('0242653')
-
-        movie.director.should be_an(Array)
-        movie.director.size.should eql(2)
-        movie.director.should include('Lana Wachowski')
-        movie.director.should include('Andy Wachowski')
+        subject { Imdb::Movie.new('0242653') }
+        it 'finds multiple directors' do
+          expect(subject.director).to match_array(%w(Lana\ Wachowski Andy\ Wachowski))
+        end
       end
 
-      it 'should find writers' do
+      context 'Waar' do
         # Waar (2013)
-        movie  = Imdb::Movie.new('1821700')
-
-        movie.writers.should be_an(Array)
-        movie.writers.size.should eql(1)
-        movie.writers.should include('Hassan Waqas Rana')
+        subject { Imdb::Movie.new('1821700') }
+        it 'finds writers' do
+          expect(subject.writers).to eq(['Hassan Waqas Rana'])
+        end
       end
     end
 
-    it 'should find multiple filming locations' do
-      filming_locations = @movie.filming_locations
-      filming_locations.should be_an(Array)
-      filming_locations.size.should eql(4)
-      filming_locations[0].should match(/.*, USA$/i)
+    it 'finds multiple filming locations' do
+      filming_locations = subject.filming_locations
+      expect(filming_locations).to be_an(Array)
+      expect(filming_locations.size).to eq(4)
+      expect(filming_locations[0]).to match(/.*, USA$/i)
     end
 
-    it "should find multiple 'also known as' versions" do
-      also_known_as = @movie.also_known_as
-      also_known_as.should be_an(Array)
-      also_known_as.size.should eql(40)
+    it "finds multiple 'also known as' versions" do
+      also_known_as = subject.also_known_as
+      expect(also_known_as).to be_a(Array)
+      expect(also_known_as.size).to eql(40)
     end
 
-    it "should find a specific 'also known as' version" do
-      also_known_as = @movie.also_known_as
-      also_known_as.should include(version: 'Russia', title: 'Крепкий орешек')
+    it "finds a specific 'also known as' version" do
+      expect(subject.also_known_as).to include(version: 'Russia', title: 'Крепкий орешек')
     end
 
-    it 'should provide a convenience method to search' do
-      movies = Imdb::Movie.search('Star Trek: TOS')
-      movies.should respond_to(:each)
-      movies.each { |movie| movie.should be_an_instance_of(Imdb::Movie) }
+    context 'Star Trek: TOS' do
+      subject { Imdb::Movie.search('Star Trek: TOS') }
+      it 'provides a convenience method to search' do
+        expect(subject).to respond_to(:each)
+        subject.each { |movie| expect(movie).to be_an_instance_of(Imdb::Movie) }
+      end
     end
 
-    it 'should provide a convenience method to top 250' do
-      movies = Imdb::Movie.top_250
-      movies.should respond_to(:each)
-      movies.each { |movie| movie.should be_an_instance_of(Imdb::Movie) }
+    context 'top 250 Movies' do
+      subject { Imdb::Movie.top_250 }
+      it 'provides a convenience method to top 250' do
+        expect(subject).to respond_to(:each)
+        subject.each { |movie| expect(movie).to be_an_instance_of(Imdb::Movie) }
+      end
     end
   end
 
   describe 'plot' do
-    it 'should find a correct plot when HTML links are present' do
-      movie = Imdb::Movie.new('0083987')
-      movie.plot.should eql('Biography of Mohandas K. Gandhi, the lawyer who became the famed leader of the Indian revolts against the British rule through his philosophy of nonviolent protest.')
+    context 'Biography of Mohandas K. Gandhi' do
+      subject { Imdb::Movie.new('0083987') }
+      it 'finds a correct plot when HTML links are present' do
+        expect(subject.plot).to eq('Biography of Mohandas K. Gandhi, the lawyer who became the famed leader of the Indian revolts against the British rule through his philosophy of nonviolent protest.')
+      end
     end
 
-    it "should not have a 'more' link in the plot" do
-      movie = Imdb::Movie.new('0036855')
-      movie.plot.should eql('Years after her aunt was murdered in her home, a young woman moves back into the house with her new husband. However, he has a secret which he will do anything to protect, even if that means driving his wife insane.')
+    context 'movie 0036855' do
+      subject { Imdb::Movie.new('0036855') }
+      it "does not have a 'more' link in the plot" do
+        expect(subject.plot).to eq('Years after her aunt was murdered in her home, a young woman moves back into the house with her new husband. However, he has a secret which he will do anything to protect, even if that means driving his wife insane.')
+      end
     end
   end
 
   describe 'mpaa rating' do
-    it 'should find the mpaa rating when present' do
-      movie = Imdb::Movie.new('0111161')
-      movie.mpaa_rating.should == 'Rated R for language and prison violence (certificate 33087)'
+    context 'movie 0111161' do
+      subject { Imdb::Movie.new('0111161') }
+      it 'finds the mpaa rating when present' do
+        expect(subject.mpaa_rating).to eq('Rated R for language and prison violence (certificate 33087)')
+      end
     end
 
-    it 'should be nil when not present' do
-      movie = Imdb::Movie.new('0095016')
-      movie.mpaa_rating.should be_nil
+    context 'movie 0095016' do
+      subject { Imdb::Movie.new('0095016') }
+      it 'is nil when not present' do
+        expect(subject.mpaa_rating).to be_nil
+      end
     end
   end
 
   describe 'with no submitted poster' do
-
-    before(:each) do
+    context 'Up is Down' do
       # Up Is Down (1969)
-      @movie = Imdb::Movie.new('1401252')
-    end
+      subject { Imdb::Movie.new('1401252') }
 
-    it 'should have a title' do
-      @movie.title(true).should =~ /Up Is Down/
-    end
+      it 'has a title' do
+        expect(subject.title(true)).to match(/Up Is Down/)
+      end
 
-    it 'should have a year' do
-      @movie.year.should eql(1969)
-    end
+      it 'has a year' do
+        expect(subject.year).to eq(1969)
+      end
 
-    it 'should return nil as poster url' do
-      @movie.poster.should be_nil
-    end
+      it 'returns nil as poster url' do
+        expect(subject.poster).to be_nil
+      end
 
-    it 'should return the release date for movies' do
-      movie = Imdb::Movie.new('0111161')
-      movie.release_date.should eql('14 October 1994 (USA)')
+      context 'movie 0111161' do
+        subject { Imdb::Movie.new('0111161') }
+        it 'returns the release date for movies' do
+          expect(subject.release_date).to eq('14 October 1994 (USA)')
+        end
+      end
     end
   end
 
   describe 'with an old poster (no @@)' do
-    before(:each) do
+    context 'Pulp Fiction' do
       # Pulp Fiction (1994)
-      @movie = Imdb::Movie.new('0110912')
-    end
-
-    it 'should have a poster' do
-      @movie.poster.should eql('http://ia.media-imdb.com/images/M/MV5BMjE0ODk2NjczOV5BMl5BanBnXkFtZTYwNDQ0NDg4.jpg')
+      subject { Imdb::Movie.new('0110912') }
+      it 'has a poster' do
+        expect(subject.poster).to eq('http://ia.media-imdb.com/images/M/MV5BMjE0ODk2NjczOV5BMl5BanBnXkFtZTYwNDQ0NDg4.jpg')
+      end
     end
   end
 
   describe 'with title that has utf-8 characters' do
-    # WALL-E
-    before(:each) do
-      @movie = Imdb::Movie.search('Wall-E').first
-    end
+    context 'WALL-E' do
+      # WALL-E
+      subject { Imdb::Movie.search('Wall-E').first }
 
-    it 'should give the proper title' do
-      @movie.title.should == 'WALL·E (2008)'
+      it 'returns the proper title' do
+        expect(subject.title).to eq('WALL·E (2008)')
+      end
     end
   end
 end

--- a/spec/imdb/search_spec.rb
+++ b/spec/imdb/search_spec.rb
@@ -1,40 +1,43 @@
 require 'spec_helper'
 
 describe 'Imdb::Search with multiple search results' do
-  before(:each) do
-    @search = Imdb::Search.new('Star Trek: TOS')
-  end
+  context 'Star Trek: TOS' do
+    subject { Imdb::Search.new('Star Trek: TOS') }
 
-  it 'should remember the query' do
-    @search.query.should == 'Star Trek: TOS'
-  end
+    it 'remembers the query' do
+      expect(subject.query).to eq('Star Trek: TOS')
+    end
 
-  it 'should find 14 results' do
-    @search.movies.size.should eql(14)
-  end
+    it 'finds 14 results' do
+      expect(subject.movies.size).to eq(14)
+    end
 
-  it 'should return Imdb::Movie objects only' do
-    @search.movies.each { |movie| movie.should be_an(Imdb::Movie) }
-  end
+    it 'returns Imdb::Movie objects only' do
+      subject.movies.each { |movie| expect(movie).to be_a(Imdb::Movie) }
+    end
 
-  it 'should not return movies with no title' do
-    @search.movies.each { |movie| movie.title.should_not be_blank }
-  end
+    it 'does not return movies with no title' do
+      subject.movies.each { |movie| expect(movie.title).to_not be_blank }
+    end
 
-  it 'should return only the title of the result' do
-    @search.movies.first.title.should eql('Star Trek (1966) (TV Series)')
+    it 'returns only the title of the result' do
+      expect(subject.movies.first.title).to eq('Star Trek (1966) (TV Series)')
+    end
   end
 end
 
 describe 'Imdb::Search with an exact match and no poster' do
-  it 'should not raise an exception' do
+  it 'does not raise an exception' do
     expect do
-      @search = Imdb::Search.new('Kannethirey Thondrinal').movies
+      subject = Imdb::Search.new('Kannethirey Thondrinal').movies
     end.not_to raise_error
   end
 
-  it 'should return the movie id correctly' do
-    @search = Imdb::Search.new('Kannethirey Thondrinal')
-    @search.movies.first.id.should eql('0330508')
+  context 'Kannethirey Thondrinal' do
+    subject { Imdb::Search.new('Kannethirey Thondrinal') }
+
+    it 'returns the movie id correctly' do
+      expect(subject.movies.first.id).to eq('0330508')
+    end
   end
 end

--- a/spec/imdb/season_spec.rb
+++ b/spec/imdb/season_spec.rb
@@ -1,41 +1,38 @@
 require 'spec_helper'
 
 describe 'Imdb::Season' do
-  before(:each) do
-    @serie = Imdb::Serie.new('1520211')
-    @season = @serie.seasons.first
-  end
+  subject      { Imdb::Serie.new('1520211') }
+  let(:season) { subject.seasons.first }
 
   it 'has 6 episodes' do
-    @season.episodes.size.should eql(6)
+    expect(season.episodes.size).to eq(6)
   end
 
   it 'can fetch a specific episode' do
-    @season.episode(1).title.should =~ /Days Gone By/i
-    @season.episode(1).episode.should eq(1)
-    @season.episode(1).season.should eq(1)
+    episode = season.episode(1)
+    expect(episode.title).to match(/Days Gone By/i)
+    expect(episode.episode).to eq(1)
+    expect(episode.season).to eq(1)
   end
 end
 
 describe 'Imdb::Season starting with episode 0' do
-  before(:each) do
-    @serie = Imdb::Serie.new('0898266')
-    @season = @serie.season(1)
-    @episodes = @serie.season(1).episodes
+  subject        { Imdb::Serie.new('0898266') }
+  let(:season)   { subject.season(1) }
+  let(:episodes) { season.episodes }
+
+  it 'indexes episode correctly' do
+    expect(episodes[0].episode).to eq(0)
+    expect(episodes[1].episode).to eq(1)
   end
 
-  it 'should index episode correctly' do
-    @episodes[0].episode.should eql(0)
-    @episodes[1].episode.should eql(1)
+  it 'returns the correct title' do
+    expect(episodes[0].title).to eq('Unaired Pilot')
+    expect(episodes[1].title).to eq('Pilot')
   end
 
-  it 'should return the correct title' do
-    @episodes[0].title.should eql('Unaired Pilot')
-    @episodes[1].title.should eql('Pilot')
-  end
-
-  it 'should fetch the correct episode' do
-    @season.episode(0).episode.should eql(0)
-    @season.episode(1).episode.should eql(1)
+  it 'fetches the correct episode' do
+    expect(season.episode(0).episode).to eq(0)
+    expect(season.episode(1).episode).to eq(1)
   end
 end

--- a/spec/imdb/series_spec.rb
+++ b/spec/imdb/series_spec.rb
@@ -1,21 +1,19 @@
 require 'spec_helper'
 
 describe 'Imdb::Serie' do
-  before(:each) do
-    @serie = Imdb::Serie.new('1520211')
-  end
+  subject { Imdb::Serie.new('1520211') }
 
   # Double check from Base.
-  it 'should find title' do
-    @serie.title.should =~ /The Walking Dead/
+  it 'finds the title' do
+    expect(subject.title).to match(/The Walking Dead/)
   end
 
   it 'reports the number of seasons' do
-    @serie.seasons.size.should eql(5)
+    expect(subject.seasons.size).to eq(5)
   end
 
   it 'can fetch a specific season' do
-    @serie.season(1).season_number.should eq(1)
-    @serie.season(1).episodes.size.should eq(6)
+    expect(subject.season(1).season_number).to eq(1)
+    expect(subject.season(1).episodes.size).to eq(6)
   end
 end

--- a/spec/imdb/top_250_spec.rb
+++ b/spec/imdb/top_250_spec.rb
@@ -1,21 +1,19 @@
 require 'spec_helper'
 
 describe Imdb::Top250 do
-  before(:each) do
-    @movies = Imdb::Top250.new.movies
-  end
+  subject { Imdb::Top250.new.movies }
 
   it 'should be a list of movies' do
-    @movies.each { |movie| movie.should be_an_instance_of(Imdb::Movie) }
+    subject.each { |movie| expect(movie).to be_an_instance_of(Imdb::Movie) }
   end
 
   it 'should return the top 250 movies from IMDB.com' do
-    @movies.size.should eq(250)
+    expect(subject.size).to eq(250)
   end
 
   it 'should provide array like access to the movies' do
-    @movies[0].title.should eq('1. The Shawshank Redemption')
-    @movies[1].title.should eq('2. The Godfather')
-    @movies[2].title.should eq('3. The Godfather: Part II')
+    expect(subject[0].title).to eq('1. The Shawshank Redemption')
+    expect(subject[1].title).to eq('2. The Godfather')
+    expect(subject[2].title).to eq('3. The Godfather: Part II')
   end
 end


### PR DESCRIPTION
* Replaced the deprecated `should` matchers with `expect(...).to`
* Used `subject` and `let` variables instead of instance variables
* Removed `"should"` wording from example descriptions
* Replaced some redundant expectations inside examples
* Utilized `match_array`, `include`, and `match` more

Addresses https://github.com/ariejan/imdb/issues/39