### PR TITLE
Edit trailer_url in base.rb

### DIFF
--- a/lib/imdb/base.rb
+++ b/lib/imdb/base.rb
@@ -58,7 +58,7 @@ module Imdb
 
     # Returns the url to the "Watch a trailer" page
     def trailer_url
-      'http://imdb.com' + document.at("a[@href*='/video/screenplay/']")['href'] rescue nil
+      'http://imdb.com' + document.at("a[@href*='/video/']")['href'] rescue nil
     end
 
     # Returns an array of genres (as strings)


### PR DESCRIPTION
trailer_url was outdated. It would return http://www.imdb.com/video/screenplay/imdb/movieid/ which would show a "This trailer is not available in your country" page. Now it returns http://www.imdb.com/video/imdb/movieid/, which does work.
