### PR TITLE
improve tagline and avoid trailing »

### DIFF
--- a/lib/imdb/base.rb
+++ b/lib/imdb/base.rb
@@ -152,7 +152,7 @@ module Imdb
 
     # Returns a string containing the tagline
     def tagline
-      document.search("h5[text()='Tagline:'] ~ div").first.inner_html.gsub(/<.+>.+<\/.+>/, '').strip.imdb_unescape_html rescue nil
+      document.at("h5[text()='Tagline:'] ~ div/text()").content.strip rescue nil
     end
 
     # Returns a string containing the mpaa rating and reason for rating

--- a/spec/imdb/movie_spec.rb
+++ b/spec/imdb/movie_spec.rb
@@ -144,7 +144,7 @@ describe 'Imdb::Movie' do
     end
 
     it 'finds the tagline' do
-      expect(subject.tagline).to match(/It will blow you through the back wall of the theater/)
+      expect(subject.tagline).to eq("It will blow you through the back wall of the theater!")
     end
 
     it 'finds the year' do


### PR DESCRIPTION
Use a cleaner way of getting the tagline, also fixes a problem where some movies with multiple taglines had a trailing "»" added to them.