### PR TITLE
add method and test for fetching the MPAA letter rating

### DIFF
--- a/lib/imdb/base.rb
+++ b/lib/imdb/base.rb
@@ -160,6 +160,11 @@ module Imdb
       document.at("//a[starts-with(.,'MPAA')]/../following-sibling::*").content.strip rescue nil
     end
 
+    # Returns a string containing the MPAA letter rating
+    def mpaa_letter_rating
+      document.at("a[@href*='certificates=us:']").content.gsub(/^USA:/, '') rescue nil
+    end
+
     # Returns a string containing the title
     def title(force_refresh = false)
       if @title && !force_refresh

--- a/spec/imdb/movie_spec.rb
+++ b/spec/imdb/movie_spec.rb
@@ -151,6 +151,10 @@ describe 'Imdb::Movie' do
       expect(subject.year).to eq(1988)
     end
 
+    it 'finds the MPAA letter rating' do
+      expect(subject.mpaa_letter_rating).to eq("R")
+    end
+
     describe 'special scenarios' do
 
       context 'The Matrix Revolutions' do


### PR DESCRIPTION
Add a method and test for getting the MPAA letter rating.

This uses IMDB's "Certification" section which is more reliable (but also less detailed) than the existing mpaa_rating method.